### PR TITLE
Added support for JWT scope checking for individual endpoints through…

### DIFF
--- a/templates/api.hbs
+++ b/templates/api.hbs
@@ -20,6 +20,16 @@ export default function(app: Express, impl: t.{{className name}}Api) {
 					res.send()
 					return
 				}
+				{{#ifvex 'x-scopes'}}
+				// At least one of the scopes from the operation needs to be in the user claims to continue
+				const scopes = [{{#each vendorExtensions.x-scopes}}'{{this}}'{{#unless @last}},{{/unless}}{{/each}}]
+				const isAuthorized = scopes.map((scope) => scope in __user).some((e) => e === true)
+				if (!isAuthorized) {
+					res.status(403)
+					res.send()
+					return
+				}
+				{{/ifvex}}
 				{{/if}}
 				{{#if requestBody.defaultContent.schema}}
 				function __body() {


### PR DESCRIPTION
… the use x-scope on an operation

This would for in the case of using a bearer token that is JWT formated allow the user to utalize scopes to be able to authorize access to different endpoints. Which is not officially supported by OpenAPI 3.0.x spec AFAIK. However it is with OpenAPI spec 3.1

@karlvr if this makes sense for you please accept the PR and do a new release och the npm package.

I do believe that an update to OpenAPI spec 3.1 would allow for scopes on all types of security schemes. But that would mean updating way more of the core generator to make it compatible