### PR TITLE
keep header name string value same as in OpenAPI spec file

### DIFF
--- a/templates/api.hbs
+++ b/templates/api.hbs
@@ -72,7 +72,7 @@ export default function(app: Express, impl: t.{{className name}}Api) {
 						res.status({{code}})
 						{{#if headers}}
 						{{#each headers}}
-						res.header({{{stringLiteral name}}}, `${response.headers[{{{stringLiteral name}}}]}`)
+						res.header({{{stringLiteral serializedName}}}, `${response.headers[{{{stringLiteral name}}}]}`)
 						{{/each}}
 						{{/if}}
 						{{#if defaultContent.schema}}


### PR DESCRIPTION
# what

just changes the template for the response header code so that the header name is kept with the original value instead of the camelCase converted string

# why

the response header names should be left as original so that someting like `My-Header-Name`, as a required response header, can be returned with that header name and _not_ returned in the HTTP response as `myHeaderName`

# issues

resolves #8 