### PR TITLE
Keep header name same as in OpenAPI spec file

### DIFF
--- a/templates/api.hbs
+++ b/templates/api.hbs
@@ -72,7 +72,7 @@ export default function(app: Express, impl: t.{{className name}}Api) {
 						res.status({{code}})
 						{{#if headers}}
 						{{#each headers}}
-						res.header({{{stringLiteral name}}}, `${response.headers[{{{stringLiteral name}}}]}`)
+						res.header({{{stringLiteral serializedName}}}, `${response.headers[{{{stringLiteral name}}}]}`)
 						{{/each}}
 						{{/if}}
 						{{#if defaultContent.schema}}


### PR DESCRIPTION
(Reopening this PR as I'd inadvertently deleted the branch when tidying up after a different merge)

# bug

- the response header names get converted to camelCase, e.g. `X-My-Header-Name` becomes `xMyHeaderName` in the generated code and are essentially unusable due to the loss of kebab-casing hyphens (regardless of case insensitivity)

# fix

- using the `serializedName` variable of the header name parsed/processed maintains the original/designed/specified header name without a case transformation, and the outputted response header names match the API docs/contract

fixes #8 