### PR TITLE
fix: set Content-Type header on 400 errors

### DIFF
--- a/.changeset/hungry-jars-scream.md
+++ b/.changeset/hungry-jars-scream.md
@@ -1,0 +1,5 @@
+---
+"@openapi-generator-plus/typescript-express-passport-server-generator": minor
+---
+
+Set Content-Type header on 400 errors.

--- a/templates/api.hbs
+++ b/templates/api.hbs
@@ -137,6 +137,7 @@ export default function(app: Express, impl: t.{{className name}}Api) {
 			} catch (error) {
 				/* Catch validation errors */
 				res.status(400)
+				res.type('text/plain; charset=utf-8')
 				res.send(error)
 			}
 		}


### PR DESCRIPTION
Resolves #16 by preventing XSS on responses with the 400 status.