### PR TITLE
feat: add support for multipart file upload

### DIFF
--- a/.changeset/spotty-pears-agree.md
+++ b/.changeset/spotty-pears-agree.md
@@ -1,0 +1,5 @@
+---
+"@openapi-generator-plus/typescript-express-passport-server-generator": minor
+---
+
+Add support for multipart file upload.

--- a/templates/api.hbs
+++ b/templates/api.hbs
@@ -1,17 +1,24 @@
 {{>header}}
 
-import { Express } from 'express'
+import { Express, Request, Response } from 'express'
 import passport from 'passport'
 import * as t from './types'
 import * as v from '../../validation'
+{{#if (isAnyOperationSupportMultipart operations)}}
+import * as f from '../../impl/helpers/{{lowerCase name}}MultipartHelper'
+{{/if}}
 import { Api } from '../../models'
 
 export default function(app: Express, impl: t.{{className name}}Api) {
 	{{#each operations}}
 	app.{{lowerCase httpMethod}}(
 		{{{stringLiteral (pathTemplate fullPath)}}},
+		{{#if (isOperationSupportsMultipart .)}}
+		f.upload.fields([{{#with (filterMultipartFiles requestBody.defaultContent.schema.properties)}}{{#each this}}{name: {{{stringLiteral name}}}, maxCount: 1}{{#hasMore}}, {{/hasMore}}{{/each}}{{/with}}]),
+		f.{{className name}}.handleFile,
+		{{/if}}
 		{{>frag/apiSecurityRequirements}}
-		function (req, res) {
+		function (req: Request, res: Response) {
 			try {
 				{{#if securityRequirements}}
 				const __user = req.user
@@ -32,6 +39,9 @@ export default function(app: Express, impl: t.{{className name}}Api) {
 						{{#unless schema}}
 						return undefined
 						{{else}}
+						{{#if (isContentSupportsMultipart .)}}
+						return req;
+						{{else}}
 						{{#ifmatch mediaType.mimeType '/json'}}
 						return {{>frag/fromJson schema prefix='v.'}}('body', req.body)
 						{{else if (isBinary schema)}}
@@ -41,6 +51,7 @@ export default function(app: Express, impl: t.{{className name}}Api) {
 						{{else}}
 						return req.body; /* Unsupported mimeType */
 						{{/ifmatch}}
+						{{/if}}
 						{{/unless}}
 					}
 					{{/each}}

--- a/templates/apiMultipartHelper.hbs
+++ b/templates/apiMultipartHelper.hbs
@@ -1,0 +1,17 @@
+import { Request, Response, NextFunction } from 'express'
+import multer from 'multer'
+import { Api } from '../../models'
+
+export const upload = multer({storage: multer.memoryStorage()})
+
+{{#each operations}}
+{{#if (isOperationSupportsMultipart .)}}
+export namespace {{className name}} {
+    /* Middleware entry point */
+    export async function handleFile(req: Request, res: Response, next: NextFunction) {
+        throw 'Unimplemented'
+    }
+}
+
+{{/if}}
+{{/each}}

--- a/templates/apiTypes.hbs
+++ b/templates/apiTypes.hbs
@@ -6,7 +6,7 @@ import { Api } from '../../models'
 export interface {{className name}}Api {
 	{{#each operations}}
 	{{identifier name}}: ({{#each parameters}}{{identifier name}}: {{{nativeType}}}{{#unless required}} | undefined{{/unless}}{{#hasMore}}, {{/hasMore}}{{/each}}{{!--
-	--}}{{#if requestBody.nativeType}}{{#if parameters}}, {{/if}}{{identifier requestBody.name}}: {{{requestBody.nativeType}}}{{#unless requestBody.required}} | undefined{{/unless}}{{/if}}{{!--
+	--}}{{#if requestBody.nativeType}}{{#if parameters}}, {{/if}}{{identifier requestBody.name}}: {{{requestBody.nativeType}}}{{#unless (isRequestRequired .)}} | undefined{{/unless}}{{/if}}{{!--
 	--}}{{#if securityRequirements}}{{#or requestBody parameters}}, {{/or}}__user: any{{/if}}{{!--
 	--}}) => Promise<{{className name}}Response>
 	{{/each}}

--- a/templates/hooks/modelsImports.hbs
+++ b/templates/hooks/modelsImports.hbs
@@ -1,3 +1,4 @@
 {{!--
 Imports to be placed at the top of the models output file.
 --}}
+import { Request } from 'express'

--- a/templates/modelGeneric.hbs
+++ b/templates/modelGeneric.hbs
@@ -2,6 +2,11 @@
 export type {{className name}} = {{{vendorExtensions.convert-to-literal-type}}}
 {{else}}
 {{>frag/schemaDocumentation}}
+{{#if (isMultipartSchema .)}}
+export interface {{className name}} extends Request {
+	body: MultipartFormData.Body;
+}
+{{else}}
 export interface {{className name}}{{#if parents}} extends {{#each parents}}{{>frag/extends extends=nativeType.parentType}}{{#hasMore}}, {{/hasMore}}{{/each}}{{/if}}{{!--
 --}}{{#if implements}}{{#unless parents}} extends{{else}},{{/unless}} {{#each implements}}{{>frag/extends extends=nativeType}}{{#hasMore}}, {{/hasMore}}{{/each}}{{/if}} {
 {{>frag/discriminator}}
@@ -18,5 +23,6 @@ export interface {{className name}}{{#if parents}} extends {{#each parents}}{{>f
 	{{#if readOnly}}readonly {{/if}}{{{quoteInvalidIdentifier serializedName}}}{{#unless required}}?{{/unless}}: {{{nativeType.serializedType}}};
 {{/each}}
 }
+{{/if}}
 {{/ifvex}}
 {{>modelNestedModels}}

--- a/templates/modelNestedModels.hbs
+++ b/templates/modelNestedModels.hbs
@@ -5,6 +5,17 @@
  * @namespace {{className name}}
  */
 export namespace {{className name}} {
+{{#if (isMultipartSchema .)}}
+    export interface Body {
+    {{#each properties}}
+        {{#unless (isMultipartSchemaPart .)}}
+        {{>frag/propertyDocumentation memberOf=../name}}
+        {{#if readOnly}}readonly {{/if}}{{{quoteInvalidIdentifier serializedName}}}{{#unless required}}?{{/unless}}: {{{nativeType.serializedType}}};
+        {{/unless}}
+    {{/each}}
+    }
+
+{{/if}}
 {{>nestedModels}}
 }
 {{/if}}

--- a/templates/nestedModels.hbs
+++ b/templates/nestedModels.hbs
@@ -1,4 +1,5 @@
 {{#each schemas}}
+	{{#unless (isMultipartSchemaPart .)}}
 	{{#if (isEnum)}}
 	{{>modelEnum}}
 	{{else if (isObject)}}
@@ -11,4 +12,5 @@
 	{{>modelInterface}}
 	{{/if}}
 
+	{{/unless}}
 {{/each}}

--- a/templates/package.hbs
+++ b/templates/package.hbs
@@ -29,6 +29,7 @@
 {{/ifeq}}
 "express": "^4.18.2"
 "passport": "^0.6.0"
+"multer": "^1.4.5-lts.1"
 {{/join}}
 		{{{__dependencies}}}
 	},
@@ -36,7 +37,8 @@
 		"@types/express": "^4.17.17",
 		"@types/node": "^18.15.11",
 		"@types/passport": "^1.0.12",
-		"typescript": "^4.9.5"
+		"typescript": "^4.9.5",
+    	"@types/multer": "^1.4.11"
 	{{#if repository}}
 	},
 	"publishConfig": {

--- a/templates/validationGeneric.hbs
+++ b/templates/validationGeneric.hbs
@@ -1,3 +1,4 @@
+{{#unless (isMultipartSchema .)}}
 const {{constantName (concat nativeType 'Keys')}}: string[] = [{{#each properties}}{{{stringLiteral serializedName}}}{{#hasMore}}, {{/hasMore}}{{/each}}]
 
 function model{{className nativeType.parentType}}FromJsonContent(name: string, value: any, knownKeys: Record<string, boolean> = {}): {{#if discriminator}}Omit<{{nativeType.parentType}}, {{{stringLiteral discriminator.serializedName}}}>{{else}}{{nativeType}}{{/if}} {
@@ -128,3 +129,4 @@ export function model{{className nativeType.parentType}}ToJson(name: string, val
 	{{/if}}
 }
 {{>nestedValidation}}
+{{/unless}}


### PR DESCRIPTION
Resolves karlvr/openapi-generator-plus-express-passport#13 by adding support for handling files uploaded in a multipart form request.

* If an API has an operation that uses a multipart request, a new helper file is created with code for handling the multipart file(s) using the Multer middleware for Express.js. Helper code is namespaced so if there is more than one multipart operation for a particular API, different handling can be implemented if needed.
* Supports single and multiple files in a multipart request.