### PR TITLE
fix: allow non required body to not fail mimeType validation

### DIFF
--- a/.changeset/optional-request-body-fix.md
+++ b/.changeset/optional-request-body-fix.md
@@ -1,0 +1,5 @@
+---
+"@openapi-generator-plus/typescript-express-passport-server-generator": patch
+---
+
+Fix generated body validation throwing "Invalid request content type" when a request has no body and `requestBody.required` is `false`.

--- a/templates/api.hbs
+++ b/templates/api.hbs
@@ -56,6 +56,11 @@ export default function(app: Express, impl: t.{{className name}}Api) {
 					const __contentType = req.get('Content-Type')
 					const __mimeType = __contentType ? __contentType.replace(/;.*/, '') : undefined
 
+					{{#unless requestBody.required}}
+					if (!__mimeType) {
+						return undefined
+					}
+					{{/unless}}
 					{{#with requestBody}}
 					{{#each contents}}
 					if (__mimeType === '{{{mediaType.mimeType}}}') {


### PR DESCRIPTION
```
requestBody:
        required: false
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/TerminalData'
```
generates
```
function __body() {
	const __contentType = req.get('Content-Type')
	const __mimeType = __contentType ? __contentType.replace(/;.*/, '') : undefined

	if (__mimeType === 'application/json') {
		return v.modelApiTerminalDataFromRequest('body', req.body)
	}
	console.error(`Invalid request content type: ${__contentType}`)
	throw new Error(`Invalid request content type: ${__contentType}`)
}
```
despite the request body being required: false